### PR TITLE
feat: add CLAUDE.md and secure Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Security: Only allow gundurraga to trigger Claude Code reviews
+    if: github.actor == 'gundurraga'
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,12 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'gundurraga' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Bad Buggy is a GitHub Action that provides AI-powered code reviews for pull requests using Claude and other AI models. It focuses on educational, constructive feedback with transparent cost tracking and incremental review capabilities.
+
+## Development Commands
+
+### Build and Compilation
+```bash
+npm run build      # Full build with ncc bundling
+npm run compile    # TypeScript compilation only  
+npm run dev        # Watch mode for development
+```
+
+### Testing and Quality
+```bash
+npm test          # Run Jest tests
+npm run lint      # ESLint on src/**/*.ts
+```
+
+### Local Development
+The Action is built using TypeScript and bundled with ncc. Main entry point is `src/main.ts` which exports a `run()` function that orchestrates the entire review workflow.
+
+## Architecture
+
+### Core Architecture Pattern
+The codebase follows a **functional core, imperative shell** architecture with domain-driven design:
+
+- **Domains** (`src/domains/`): Pure business logic functions for cost calculation, GitHub formatting, review processing, and security validation
+- **Effects** (`src/effects/`): Impure side effects for AI API calls, file system operations, and GitHub API interactions  
+- **Services** (`src/services/`): Orchestration layer that coordinates domains and effects
+- **Types** (`src/types.ts`): Comprehensive type definitions for all domain objects
+
+### Workflow Orchestration
+The main workflow is managed by `ReviewWorkflow` class in `src/services/workflow.ts` which:
+1. Validates inputs and configuration
+2. Performs security checks and permission validation
+3. Processes incremental diffs (only reviews new changes)
+4. Chunks large diffs for AI processing
+5. Posts review comments and cost summaries
+
+### Security Model
+- `CredentialManager` singleton handles API key management
+- User permission validation through GitHub API
+- Security checks for fork-based PRs and user allowlists
+- Access control validation in `src/security/access-control.ts`
+
+### AI Provider Abstraction
+- Supports Anthropic and OpenRouter providers
+- Token counting and cost calculation per provider
+- Provider-specific response handling in `src/effects/ai-api.ts`
+
+## Configuration System
+
+### Default Configuration
+Located in `src/config/default-config.ts` with comprehensive review prompts focusing on:
+- Architecture and design patterns
+- Code quality and best practices  
+- Educational feedback approach
+- Maximum 5 high-impact comments per review
+
+### User Configuration
+Users can override defaults via `.github/ai-review-config.yml`:
+- Custom prompts for project-specific context
+- File ignore patterns
+- User allowlists
+- Comment limits
+
+## Key Features
+
+### Incremental Reviews
+- Tracks review state per PR in repository
+- Only reviews new commits since last review
+- Contextual awareness of previous reviews
+
+### Smart Context
+- Repository structure analysis
+- ~100 lines of context around changes
+- Package.json analysis for project understanding
+
+### Cost Optimization
+- Intelligent diff chunking to stay within token limits
+- Transparent cost reporting with per-review breakdowns
+- Provider-specific pricing calculations
+
+## Development Notes
+
+### TypeScript Configuration
+- Strict type checking enabled
+- CommonJS modules targeting ES2020
+- Source maps and declarations generated
+- Test files excluded from compilation
+
+### Error Handling
+- Custom error types: `ConfigValidationError`, `AIProviderError`
+- Structured error classification with specific exit codes
+- Comprehensive logging through `Logger` service
+
+### Testing Strategy
+When adding tests, use Jest framework. Test files should be in `**/*.test.ts` pattern (excluded from compilation).
+
+### GitHub Action Specifics
+- Action metadata in `action.yml` 
+- Built artifact is `dist/index.js` (not `dist/main.js`)
+- Requires Node 20 runtime
+- Input validation through GitHub Actions core library


### PR DESCRIPTION
## Summary
- Add comprehensive CLAUDE.md documentation for Claude Code instances
- Secure Claude workflows by restricting execution to repository owner only
- Prevent quota abuse from external contributors

## Changes Made
- **CLAUDE.md**: Complete documentation of codebase architecture, commands, and development patterns
- **claude.yml**: Added `github.actor == 'gundurraga'` restriction to @claude triggers
- **claude-code-review.yml**: Added user restriction to automatic PR reviews

## Security Benefits
- External contributors cannot trigger Claude and drain API quota
- Only repository owner can invoke Claude through comments or PR creation
- Protects against malicious fork PRs attempting to access Claude

## Test Plan
- [ ] Verify Claude workflows only trigger for gundurraga user
- [ ] Test that external contributor comments with @claude are ignored
- [ ] Confirm automatic PR reviews only run for owner-created PRs

🤖 Generated with [Claude Code](https://claude.ai/code)